### PR TITLE
Version 1.6.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ mirai {
 }
 
 group = "com.pigeonyuze"
-version = "1.6.0"
+version = "1.6.0-RC"
 
 repositories {
     maven("https://maven.aliyun.com/repository/public")

--- a/src/main/kotlin/com/pigeonyuze/LoggerManager.kt
+++ b/src/main/kotlin/com/pigeonyuze/LoggerManager.kt
@@ -1,70 +1,87 @@
 package com.pigeonyuze
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import net.mamoe.mirai.message.data.ForwardMessageBuilder
 import net.mamoe.mirai.message.data.PlainText
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.coroutines.CoroutineContext
 
 @Suppress("UNUSED")
-object LoggerManager {
+object LoggerManager : CoroutineScope {
 
-    private inline val notRun get() = !LoggerConfig.open
+    override val coroutineContext: CoroutineContext = CoroutineExceptionHandler { _, error ->
+        loggingError(error)
+    } + YamlBot.coroutineContext + SupervisorJob(YamlBot.coroutineContext[Job])
 
-    private val miraiLogger = YamlBot.logger
+    private val miraiLogger by lazy { YamlBot.logger }
 
     private const val defaultfrom = "YamlBot"
 
+    private val dateFormat: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
     @JvmOverloads
     @JvmStatic
     fun loggingError(from: Any = defaultfrom, message: String?) {
-        if (notRun) return
+        if (!LoggerConfig.open) return
         miraiLogger.error("[$from] $message")
-        trySendLogMessage(message ?: "")
+        trySendLogMessage("ERROR", from.toString(), message ?: "")
+    }
+
+    fun loggingError(error: Throwable) {
+        if (!LoggerConfig.open) return
+        miraiLogger.error(error)
+        trySendLogMessage("ERROR", error.javaClass.simpleName, error.message ?: "")
     }
 
     @JvmOverloads
     @JvmStatic
     fun loggingWarn(from: Any = defaultfrom, message: String?) {
-        if (notRun) return
+        if (!LoggerConfig.open) return
         miraiLogger.warning("[$from] $message")
     }
 
     @JvmOverloads
     @JvmStatic
     fun loggingInfo(from: Any = defaultfrom, message: String?) {
-        if (notRun) return
+        if (!LoggerConfig.open) return
         miraiLogger.info("[$from] $message")
     }
 
     @JvmOverloads
     @JvmStatic
     fun loggingDebug(from: Any = defaultfrom, message: String?) {
-        if (notRun) return
+        if (!LoggerConfig.open) return
         miraiLogger.debug("[$from] $message")
     }
 
     @JvmOverloads
     @JvmStatic
     fun loggingTrace(from: Any = defaultfrom, message: String?) {
-        if (notRun) return
+        if (!LoggerConfig.open) return
         miraiLogger.verbose("[$from] $message")
     }
 
-    private fun trySendLogMessage(message: String) {
-        val bot = BotsTool.firstBot
-        val group = BotsTool.getGroupOrNullJava(LoggerConfig.debugGroup) ?: return
-        val forwardMessageBuilder = ForwardMessageBuilder(group)
-        forwardMessageBuilder.add(
-            bot,
-            PlainText("${SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(Date())} log message\nlevel type = ERROR")
-        )
-        forwardMessageBuilder.add(bot, PlainText(message))
-        runBlocking {
+    @Suppress("SameParameterValue")
+    private fun trySendLogMessage(level: String, from: String, message: String) {
+        if (LoggerConfig.debugGroup == 0L) return
+        launch {
+            val group = BotsTool.getGroupOrNull(LoggerConfig.debugGroup) ?: return@launch
+
+            val forwardMessageBuilder = ForwardMessageBuilder(group)
+                .add(
+                    group.bot,
+                    PlainText("${LocalDateTime.now().format(dateFormat)} log message")
+                )
+                .add(
+                    group.bot,
+                    PlainText("level type = $level\nfrom = $from\nmessage = $message")
+                )
+
             group.sendMessage(
                 forwardMessageBuilder.build()
-                    .copy(title = "Log信息", summary = "level = ERROR", preview = listOf("(●'◡'●)"))
+                    .copy(title = "Log信息", summary = "level = $level", preview = listOf("(●'◡'●)"))
             )
         }
     }

--- a/src/main/kotlin/com/pigeonyuze/command/Command.kt
+++ b/src/main/kotlin/com/pigeonyuze/command/Command.kt
@@ -414,8 +414,7 @@ sealed interface Command {
 
             val args = /* Get values from native message*/
                 if (argsSplit.isEmpty() && argsSize == 1) {
-                    println("IT IS CAN BE NATIVE MSG")
-                    msg.asParameter()
+                    Parameter(listOf(msg))
                 } else msg.split(argsSplit).asParameter().removeFirst()
 
             LoggerManager.loggingDebug("ArgCommand-run", "Args from native message: $args")

--- a/src/main/kotlin/com/pigeonyuze/command/Command.kt
+++ b/src/main/kotlin/com/pigeonyuze/command/Command.kt
@@ -173,6 +173,7 @@ sealed interface Command {
             return template.execute(args)
         }
 
+        @Suppress("FunctionName")
         private fun Command._initImpl() {
             val run by lazy { this.run }
             val name by lazy { this.name }
@@ -518,6 +519,7 @@ sealed interface Command {
          * 反之则返回`null`
          * */
         private inline fun <K> checkCommandName(checkNativeObj: String, shouldBe: String, run: () -> K): K? {
+            println("$checkNativeObj == $shouldBe , by $isPrefixForAll.")
             if (isPrefixForAll) {
                 if (checkNativeObj.startsWith(shouldBe)) {
                     return run.invoke()

--- a/src/main/kotlin/com/pigeonyuze/command/YamlCommandDecoder.kt
+++ b/src/main/kotlin/com/pigeonyuze/command/YamlCommandDecoder.kt
@@ -1,8 +1,7 @@
 package com.pigeonyuze.command
 
-import com.pigeonyuze.CommandConfigs
+import com.pigeonyuze.*
 import com.pigeonyuze.CommandPolymorphism
-import com.pigeonyuze.YamlBot
 import com.pigeonyuze.YamlBot.reload
 import com.pigeonyuze.command.Command.*
 import com.pigeonyuze.command.Command.ArgCommand.Type.*
@@ -93,7 +92,7 @@ object YamlCommandDecoder : PluginDataStorage {
         val argsSplit = (commandElement["argsSplit"] as? YamlLiteral)?.content ?: " "
         val requestYaml = commandElement["request"] as? YamlMap
         val describeYaml = commandElement["describe"] as? YamlMap
-        val isPrefixForAll = (commandElement["isPrefix"] as? YamlLiteral)?.content?.toBooleanStrictOrNull() ?: true
+        val isPrefixForAll = (commandElement["isPrefixForAll"] as? YamlLiteral)?.content?.toBooleanStrictOrNull() ?: true
         val name = mutableListOf<String>()
         for (oneNameElement in nameYaml) {
             if (oneNameElement !is YamlLiteral) name.add(oneNameElement.toString())
@@ -266,14 +265,15 @@ object YamlCommandDecoder : PluginDataStorage {
             file.copyTo(file.resolveSibling("${file.name}.${System.currentTimeMillis()}.bak"))
             throw e
         }
-
+        LoggerManager.loggingDebug("load-command","Start read CommandReg.yml ->")
         val commands = (yaml as YamlMap)["COMMAND"] as YamlList
         val commandList = mutableListOf<CommandPolymorphism>()
-        for (commandYaml in commands) { //循环尝试反序列化为一个Command类
+        for ((index,commandYaml) in commands.withIndex()) { //循环尝试反序列化为一个Command类
             if (commandYaml !is YamlMap) continue
             val command: Command =
                 readToArgsCommand(commandYaml) ?: readToCommand(commandYaml) ?: readToOnlyCommand(commandYaml)
                 ?: illegalArgument("Cannot initialize object to a command!")
+            LoggerManager.loggingTrace("load-command","$command #$index")
             commandList.add(command.toPolymorphismObject())
         }
         CommandConfigs.COMMAND = commandList

--- a/src/main/kotlin/com/pigeonyuze/listener/YamlEventListenerDecoder.kt
+++ b/src/main/kotlin/com/pigeonyuze/listener/YamlEventListenerDecoder.kt
@@ -68,10 +68,7 @@ object YamlEventListenerDecoder : PluginDataStorage {
     }
 
     private fun getSerializedString(eventListeners: List<EventListener>): String {
-        return Yaml {
-            mapSerialization = YamlBuilder.MapSerialization.BLOCK_MAP
-            listSerialization = YamlBuilder.ListSerialization.BLOCK_SEQUENCE
-        }.encodeToString(eventListeners)
+        return Yaml.encodeToString(eventListeners)
     }
 
     private fun yamlElementToTemplateYML(oneRunElement: YamlMap): TemplateYML {

--- a/src/main/kotlin/com/pigeonyuze/listener/impl/data/groupBot.kt
+++ b/src/main/kotlin/com/pigeonyuze/listener/impl/data/groupBot.kt
@@ -229,7 +229,7 @@ private class BotJoinGroupEventListener(template: MutableMap<String, Any>) :
     override fun findSubclass(name: String): ListenerImpl<out BotJoinGroupEvent> {
         return when (name) {
             "Active" -> subclassList[0]
-            "Kick" -> subclassList[1]
+            "Invite" -> subclassList[1]
             "Retrieve" -> subclassList[2]
             else -> throw NotImplementedError()
         }

--- a/src/main/kotlin/com/pigeonyuze/setting/Configs.kt
+++ b/src/main/kotlin/com/pigeonyuze/setting/Configs.kt
@@ -42,8 +42,8 @@ suspend fun ListenerConfigs.startAllListener() {
 object LoggerConfig : AutoSavePluginConfig("LoggerConfig") {
     @ValueDescription(
         """
-        是否开启日志系统，当关闭时不再会输出任何日志信息
-        除非出现了要求被用户查看的错误，如运行错误或者错误的参数时使用
+        是否开启日志系统，当关闭时不再会输出主动发出的任何日志信息
+        除非出现了被动的错误，如运行错误或者错误的参数时输出错误
     """
     )
     val open: Boolean by value(true)

--- a/src/main/kotlin/com/pigeonyuze/template/Parameter.kt
+++ b/src/main/kotlin/com/pigeonyuze/template/Parameter.kt
@@ -454,7 +454,6 @@ fun YamlList.asParameter(): Parameter {
 }
 
 fun List<String>.asParameter(): Parameter {
-    println("is this")
     return Parameter(this)
 }
 

--- a/src/main/kotlin/com/pigeonyuze/template/Parameter.kt
+++ b/src/main/kotlin/com/pigeonyuze/template/Parameter.kt
@@ -1,6 +1,6 @@
 package com.pigeonyuze.template
 
-import com.pigeonyuze.command.Command.Companion.parseData
+import com.pigeonyuze.LoggerManager
 import com.pigeonyuze.command.element.illegalArgument
 import com.pigeonyuze.util.*
 import com.pigeonyuze.util.SerializerData.SerializerType.*
@@ -19,7 +19,6 @@ class Parameter constructor() {
 
     val stringValueList
         get() = _stringValue
-
 
     private constructor(value: List<Any>, _stringValue: List<String>) : this() {
         this.value.addAll(value)
@@ -118,12 +117,12 @@ class Parameter constructor() {
     fun parseElement(templateCall: MutableMap<String, Any?>): Parameter { //不对本值进行任何修改，具有唯一性
         val ret = Parameter()
         for (arg in _stringValue) {
-            val data = if (arg.contains("%call-")) parseData(
-                arg,
-                templateCall
-            ) else arg
+            val data = if (arg.startsWith("%call-") && arg.endsWith("%")) {
+                LoggerManager.loggingTrace("Parameter-parseElement","Find `call` evaluate,start parse element.")
+                templateCall[arg.drop(6).dropLast(1)] ?: throw IllegalArgumentException("Cannot find value --> $arg from $templateCall")
+            }else arg
             ret.value.add(data)
-            ret._stringValue.add(data)
+            ret._stringValue.add(data.toString())
         }
         return ret
     }
@@ -236,7 +235,6 @@ class Parameter constructor() {
     override fun toString(): String {
         return value.toString()
     }
-
     inner class ParameterValueReader {
         private val value: List<Any> = this@Parameter.value
 
@@ -433,6 +431,7 @@ fun YamlList.asParameter(): Parameter {
 }
 
 fun List<String>.asParameter(): Parameter {
+    println("is this")
     return Parameter(this)
 }
 

--- a/src/main/kotlin/com/pigeonyuze/template/Parameter.kt
+++ b/src/main/kotlin/com/pigeonyuze/template/Parameter.kt
@@ -5,7 +5,6 @@ import com.pigeonyuze.command.element.illegalArgument
 import com.pigeonyuze.util.*
 import com.pigeonyuze.util.SerializerData.SerializerType.*
 import net.mamoe.mirai.contact.Contact
-import net.mamoe.mirai.contact.Group
 import net.mamoe.mirai.event.Event
 import net.mamoe.mirai.event.events.MessageEvent
 import net.mamoe.mirai.message.data.Message
@@ -100,7 +99,6 @@ class Parameter constructor() {
     fun withIndex() = value.withIndex()
     operator fun get(index: Int) = _stringValue[index]
     fun subList(fromIndex: Int, toIndex: Int = lastIndex): MutableList<Any> {
-        Group
         if (fromIndex < 0) throw IndexOutOfBoundsException("fromIndex = $fromIndex")
         if (toIndex > size) throw IndexOutOfBoundsException("toIndex = $toIndex")
         require(fromIndex <= toIndex) {

--- a/src/main/kotlin/com/pigeonyuze/template/data/JvmReflectionTemplate.kt
+++ b/src/main/kotlin/com/pigeonyuze/template/data/JvmReflectionTemplate.kt
@@ -1,6 +1,6 @@
 package com.pigeonyuze.template.data
 
-import com.pigeonyuze.com.pigeonyuze.LoggerManager
+import com.pigeonyuze.LoggerManager
 import com.pigeonyuze.command.element.NullObject
 import com.pigeonyuze.template.Parameter
 import com.pigeonyuze.template.Template


### PR DESCRIPTION
Update version 1.6.0

fix some bugs

:bug: Fix wrong name of subclass in BotJoinGroupEventListener
:recycle: Remove excess imports in Parameter.kt
:recycle: Remove non-log output in Command.kt
:bug: Fix cannot parse element to non-string value
:bug: Fix cannot parse some `template-call`
:sparkles: Support for SerializerData with EventListener
:wrench: Modify the description of LoggerConfig
:wrench: Modify EventListener's YAML serialization format
:bug: Fix cannot read property isPrefixForAll from YAML #21

close #21